### PR TITLE
Name displayment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,6 @@ typings/
 # own stuff
 dist/
 dist-*/
+
+# Jetbrains
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# locks
+*.lock
+yarn.lock
+
 # Runtime data
 pids
 *.pid

--- a/template/html.hbs
+++ b/template/html.hbs
@@ -75,6 +75,7 @@
               <span class="inner">
                   <{{ ../baseTag }} class="{{ ../classPrefix }}{{ this }}"></{{ ../baseTag }}>
               </span>
+              <br>
               <span class='label'>{{ this }}</span>
           </div>
 

--- a/template/html.hbs
+++ b/template/html.hbs
@@ -12,9 +12,16 @@
             text-align: center;
         }
 
+        .icons {
+          display: flex;
+          justify-content: center;
+          flex-wrap: wrap;
+        }
+
         .preview {
             width: 100px;
-            display: inline-block;
+            display: flex;
+            flex-direction: column;
             margin: 10px;
         }
 
@@ -35,6 +42,7 @@
         }
 
         .label {
+            flex-grow: 1;
             display: inline-block;
             width: 100%;
             box-sizing: border-box;
@@ -42,9 +50,7 @@
             font-size: 10px;
             font-family: Monaco, monospace;
             color: #666;
-            white-space: nowrap;
             overflow: hidden;
-            text-overflow: ellipsis;
             background: #ddd;
             -webkit-border-radius: 0 0 3px 3px;
             -moz-border-radius: 0 0 3px 3px;
@@ -56,23 +62,25 @@
     </style>
 </head>
 <body>
+    <div>
+      <h1>{{ fontName }}</h1>
+      <p>These lines should <i class="fg-phone"></i> help to figure out the behavior of
+        the <i class="fg-questionmark-circle"></i> icon font set.</p>
+      <p>HH<i class="fg-questionmark-circle"></i>HH ... gg<i class="fg-questionmark-circle"></i>gg</p>
+    </div>
+    <div class="icons">
+      {{# each names }}
 
-    <h1>{{ fontName }}</h1>
-    <p>These lines should <i class="fg-phone"></i> help to figure out the behavior of
-      the <i class="fg-questionmark-circle"></i> icon font set.</p>
-    <p>HH<i class="fg-questionmark-circle"></i>HH ... gg<i class="fg-questionmark-circle"></i>gg</p>
+          <div class="preview">
+              <span class="inner">
+                  <{{ ../baseTag }} class="{{ ../classPrefix }}{{ this }}"></{{ ../baseTag }}>
+              </span>
+              <br>
+              <span class='label'>{{ this }}</span>
+          </div>
 
-    {{# each names }}
-
-        <div class="preview">
-            <span class="inner">
-                <{{ ../baseTag }} class="{{ ../classPrefix }}{{ this }}"></{{ ../baseTag }}>
-            </span>
-            <br>
-            <span class='label'>{{ this }}</span>
-        </div>
-
-    {{/ each }}
+      {{/ each }}
+    </div>
 
 </body>
 </html>

--- a/template/html.hbs
+++ b/template/html.hbs
@@ -75,7 +75,6 @@
               <span class="inner">
                   <{{ ../baseTag }} class="{{ ../classPrefix }}{{ this }}"></{{ ../baseTag }}>
               </span>
-              <br>
               <span class='label'>{{ this }}</span>
           </div>
 


### PR DESCRIPTION
Revived this from pre-re-structuring of teams.
This PR is doing a small nice thing. Basically displaying the names a bit better.

It's rebased and updated to the current commits.

<img width="493" alt="screen shot 2018-10-09 at 11 26 54" src="https://user-images.githubusercontent.com/4340405/46660117-a2c36180-cbb6-11e8-8901-1fe493b859d1.png">
See the two lines and the one liners' boxes. ;)